### PR TITLE
Subcluster no strays

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: InSituType
 Type: Package
 Title: An R package for performing cell typing in SMI and other single cell data
-Version: 0.99.2
+Version: 0.99.3
 Authors@R: c(person("Patrick", "Danaher", email = "pdanaher@nanostring.com", role = c("aut", "cre")),
              person("Zhi", "Yang", email = "zyang@nanostring.com", role = c("aut")),
              person("David", "Ross", email = "dross@nanostring.com", role = c("aut")))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# InSituType 0.99.3
+
+* Merge subclustering fix
+
 # InSituType 0.99.2
 
 * Optionally use SingleCellExperiment class


### PR DESCRIPTION
In `refineClusters` don't allow cells to be assigned outside of the original supercluster even if logliks become more favorable to another supercluster.